### PR TITLE
Fix essence of comedy being perishable

### DIFF
--- a/data/jokers.lua
+++ b/data/jokers.lua
@@ -220,7 +220,7 @@ SMODS.Joker { -- Essence of Comedy
     unlocked = true,
     discovered = false,
     blueprint_compat = true,
-    perishable_compat = true,
+    perishable_compat = false,
     eternal_compat = true,
     rarity = 2,
     cost = 6,


### PR DESCRIPTION
(Can't open an issue for it so have to make a whole fork for the pr)

Essence of Comedy can be perishable, which in accordance to vanilla behavior it shouldn't be because it's a scaling joker.