### PR TITLE
Redux compatibility talisman + others

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -251,6 +251,20 @@ payload = '''
 if v == 'polychrome_alchemical' then info_queue[#info_queue+1] = {key = 'e_polychrome_alchemical', set = 'Edition', config = {extra = 1.5}} end
 '''
 
+# try to fix codex arcanum crashes with multiple mods(seems to be working)
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = '''if amt > 0 or amt < 0 then'''
+position = 'before'
+match_indent = true
+times = 1
+payload = '''
+if type(amt) == "table" and amt.to_number then
+    amt = amt:to_number()
+end
+'''
+
 [[patches]]
 [patches.pattern]
 target = "card.lua"


### PR DESCRIPTION
When trying to remove temporary card effects from the cards after the round the game crashes with an error related to common_events lua. This patch fixes that case. Haven't found other cases of crashing after removing effects so far.